### PR TITLE
Export  AjaxAngular2Adapter

### DIFF
--- a/src/breeze-bridge-angular2.ts
+++ b/src/breeze-bridge-angular2.ts
@@ -92,7 +92,7 @@ interface DsaConfig {
 }
 
 ////////////////////
-class AjaxAngular2Adapter {
+export class AjaxAngular2Adapter {
   static adapterName = 'angular2';
   name = AjaxAngular2Adapter.adapterName;
   defaultSettings = {};


### PR DESCRIPTION
so someone can create one later. See [this StackOverflow comment](https://github.com/Breeze/breeze.js/issues/173#issuecomment-263749575) for why.