### PR TITLE
Fix for unnecessary CORS pre-flight OPTIONS request on query calls

### DIFF
--- a/src/breeze-bridge-angular2.ts
+++ b/src/breeze-bridge-angular2.ts
@@ -130,7 +130,7 @@ export class AjaxAngular2Adapter {
 
     let headers = new Headers(config.headers || {});
     if (!headers.has('Content-Type')) {
-      if (config.contentType !== false) {
+      if (config.type != 'GET' && config.type != 'DELETE' && config.contentType !== false) {
         headers.set('Content-Type',
          <string> config.contentType || 'application/json; charset=utf-8');
       }


### PR DESCRIPTION
The Content-Type header was being set on every request, resulting in
CORS pre-flight OPTIONS on Metadata and query calls because CORS requires pre-flight OPTIONS call for any headers other than Accept.